### PR TITLE
Updated fisherman install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For now you can install it with either Fish plugin manager (you can also install
 
 * Using [fisherman](https://github.com/fisherman/fisherman):
   ```fish
-  fisher install laughedelic/brew-completions
+  fisher add laughedelic/brew-completions
   ```
 
 * Using [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish):


### PR DESCRIPTION
The command `fisher install` doesn't exist on the latest version of fisherman. `fisher add` should be used instead.